### PR TITLE
Point Mictronics aircraft database download at GitHub source

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -14,7 +14,7 @@ function getGIT() {
 getGIT https://github.com/ADSBexchange/adsbx-type-longnames.git main "$(pwd)/longnames"
 
 wget -O newTypes.json https://raw.githubusercontent.com/Mictronics/readsb-protobuf/dev/webapp/src/db/types.json
-wget -O mic-db.zip https://www.mictronics.de/aircraft-database/indexedDB_old.php
+wget -O mic-db.zip https://raw.githubusercontent.com/Mictronics/aircraft-database/main/indexedDB_old.zip
 unzip -o mic-db.zip
 
 # wget -O basic-ac-db.json.gz https://downloads.adsbexchange.com/downloads/basic-ac-db.json.gz


### PR DESCRIPTION
## Summary

The `sync_tar1090_db-prod`/`-dev` CodeBuild jobs have been publishing stale aircraft data. `update.sh` downloads the Mictronics aircraft database from `https://www.mictronics.de/aircraft-database/indexedDB_old.php`, which now returns HTTP 404 — Mictronics retired the PHP download interface and moved the exports to `github.com/Mictronics/aircraft-database`.

Because `update.sh` runs with `set -e`, it stops at the failed download (before `toJson.py`), while the wrapping `updateS3.sh` has no `set -e` and continues — so the build still reports SUCCEEDED, re-uploads the stale committed `db/*.js`, and never regenerates `aircraft.csv` (the `7za aircraft.csv.gz` step errors with "path does not exist").

This change points the download at the GitHub-hosted `indexedDB_old.zip`. The zip contains the same `aircrafts.json`, `types.json`, and `operators.json` the script consumes, and is current (stamped 2026-07-05).

## Impact

- Restores fresh Mictronics data to the `tar1090-db` build on `master` (feeds `sync_tar1090_db-prod`).
- No change to the download/unzip flow — same output filename, same `unzip -o mic-db.zip`.

## Notes / follow-ups (not in this PR)

- The identical URL is fixed on `dev` in a separate PR, and in the upstream Registration Ingest `mictronics-imp.sh` on the ops EC2.
- `updateS3.sh` continues past a failed `update.sh`, so a dead source ships as a SUCCEEDED build; adding an exit-code/size guard would surface this next time.
- The auto-update commit on this branch has not advanced since 2026-03-25, which predates the Mictronics break; the nightly `git push -f` may have a separate issue worth checking once builds run green again.