### PR TITLE
Point Mictronics aircraft database download at GitHub source (dev)

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -36,7 +36,7 @@ fi
 echo ""
 
 echo "[4/8] Downloading Mictronics aircraft database..."
-wget -O mic-db.zip https://www.mictronics.de/aircraft-database/indexedDB_old.php
+wget -O mic-db.zip https://raw.githubusercontent.com/Mictronics/aircraft-database/main/indexedDB_old.zip
 echo "  Done"
 echo ""
 


### PR DESCRIPTION
## Summary

Companion to the `master` PR. `update.sh` on `dev` downloads the Mictronics aircraft database from `https://www.mictronics.de/aircraft-database/indexedDB_old.php`, which now returns HTTP 404 — Mictronics retired the PHP download interface and moved the exports to `github.com/Mictronics/aircraft-database`. This breaks the `sync_tar1090_db-dev` CodeBuild job (aborts at the download; build still reports SUCCEEDED and ships stale data).

This change points the download at the GitHub-hosted `indexedDB_old.zip`, which contains the same `aircrafts.json`, `types.json`, and `operators.json` and is current (stamped 2026-07-05).

## Impact

- Restores fresh Mictronics data to the `dev` build (feeds `sync_tar1090_db-dev`).
- No change to the download/unzip flow.